### PR TITLE
Fix path in generated Routes by Dekorate

### DIFF
--- a/src/main/java/dev/snowdrop/example/service/DummyController.java
+++ b/src/main/java/dev/snowdrop/example/service/DummyController.java
@@ -1,0 +1,19 @@
+package dev.snowdrop.example.service;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Workaround for Dekorate to expose routes at path `/`. Otherwise, it will use the path from `FruitController`: /api/fruits.
+ * Without this workaround, the static resources like `index.html` cannot be accessed via the route when deployed in OCP.
+ * It should be fixed using Dekorate 2.7.
+ */
+@RestController
+@RequestMapping(value = "/dummy")
+public class DummyController {
+    @GetMapping
+    public String get() {
+        return "Hello";
+    }
+}

--- a/src/test/java/dev/snowdrop/example/AbstractApplicationTest.java
+++ b/src/test/java/dev/snowdrop/example/AbstractApplicationTest.java
@@ -21,13 +21,26 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 
-import io.restassured.http.ContentType;
 import java.util.Collections;
+
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
 
 public abstract class AbstractApplicationTest {
 
     protected static final String FRUITS_PATH = "/api/fruits";
+
+    private static final String INDEX_HTML = "index.html";
+
+    @Test
+    public void testGetIndex() {
+        given()
+                .baseUri(baseURI())
+                .get(INDEX_HTML)
+                .then().statusCode(HttpStatus.SC_OK);
+    }
 
     @Test
     public void testPostGetAndDelete() {

--- a/src/test/java/dev/snowdrop/example/ManagedOpenShiftIT.java
+++ b/src/test/java/dev/snowdrop/example/ManagedOpenShiftIT.java
@@ -16,43 +16,38 @@
 
 package dev.snowdrop.example;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import io.dekorate.testing.annotation.Inject;
 import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.LocalPortForward;
-import java.io.IOException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 @DisabledIfSystemProperty(named = "unmanaged-test", matches = "true")
 @OpenshiftIntegrationTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ManagedOpenShiftIT extends AbstractApplicationTest {
 
     @Inject
     KubernetesClient client;
 
-    @Inject
-    Pod pod;
+    String baseURI;
 
-    LocalPortForward appPort;
-
-    @BeforeEach
+    @BeforeAll
     public void setup() {
-        appPort = client.pods().withName(pod.getMetadata().getName()).portForward(8080);
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        if (appPort != null) {
-            appPort.close();
-        }
+        // TODO: In Dekorate 2.7, we can inject Routes directly, so we won't need to do this:
+        Route route = client.adapt(OpenShiftClient.class).routes().withName("crud").get();
+        String protocol = route.getSpec().getTls() == null ? "http" : "https";
+        int port = "http".equals(protocol) ? 80 : 443;
+        baseURI = String.format("%s://%s:%s/", protocol, route.getSpec().getHost(), port, "/");
     }
 
     @Override
     public String baseURI() {
-        return "http://localhost:" + appPort.getLocalPort() + "/";
+        return baseURI;
     }
 
 }

--- a/src/test/java/dev/snowdrop/example/UnmanagedOpenShiftIT.java
+++ b/src/test/java/dev/snowdrop/example/UnmanagedOpenShiftIT.java
@@ -16,43 +16,38 @@
 
 package dev.snowdrop.example;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
 import io.dekorate.testing.annotation.Inject;
 import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.LocalPortForward;
-import java.io.IOException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 @EnabledIfSystemProperty(named = "unmanaged-test", matches = "true")
 @OpenshiftIntegrationTest(deployEnabled = false, buildEnabled = false, pushEnabled = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UnmanagedOpenShiftIT extends AbstractApplicationTest {
 
     @Inject
     KubernetesClient client;
 
-    @Inject
-    Pod pod;
+    String baseURI;
 
-    LocalPortForward appPort;
-
-    @BeforeEach
+    @BeforeAll
     public void setup() {
-        appPort = client.pods().withName(pod.getMetadata().getName()).portForward(8080);
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        if (appPort != null) {
-            appPort.close();
-        }
+        // TODO: In Dekorate 2.7, we can inject Routes directly, so we won't need to do this:
+        Route route = client.adapt(OpenShiftClient.class).routes().withName("crud").get();
+        String protocol = route.getSpec().getTls() == null ? "http" : "https";
+        int port = "http".equals(protocol) ? 80 : 443;
+        baseURI = String.format("%s://%s:%s/", protocol, route.getSpec().getHost(), port, "/");
     }
 
     @Override
     public String baseURI() {
-        return "http://localhost:" + appPort.getLocalPort() + "/";
+        return baseURI;
     }
 
 }


### PR DESCRIPTION
It seems to be a bug in Dekorate 2.4.1 where we cannot overwrite the path. A workaround has been added to fix it.