### PR TITLE
bump dekorate 2.11.5 and removed default maven settings on dekorate OCP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Project using Dekorate
         run: |
           oc new-project dekorate
-          ./run_tests_with_dekorate_in_ocp.sh
+          ./run_tests_with_dekorate_in_ocp.sh -s .github/mvn-settings.xml
       - name: Delete Project using Dekorate
         run: oc delete project dekorate
       - name: Clean folder

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ version as a `-D<variable property name>=value` parameter. For instance overridi
 ./run_tests_with_dekorate_in_ocp.sh -Dspring-boot.version=2.7.3 -Ddekorate.version=2.11.1
 ```
 
-
 ## Running Tests on OpenShift using S2i from Source
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <postgresql.version>42.4.1</postgresql.version>
     <spring-boot.version>2.7.2</spring-boot.version>
     
-    <dekorate.version>2.11.4</dekorate.version>
+    <dekorate.version>2.11.5</dekorate.version>
 
     <!-- Overridden from Spring Boot -->
     <hibernate.version>5.6.10.Final</hibernate.version>

--- a/run_tests_with_dekorate_in_ocp.sh
+++ b/run_tests_with_dekorate_in_ocp.sh
@@ -8,4 +8,4 @@ if [[ $(waitFor "my-database" "app") -eq 1 ]] ; then
 fi
 
 # Run Tests
-eval "./mvnw -s .github/mvn-settings.xml clean verify -Popenshift,openshift-it $@"
+eval "./mvnw clean verify -Popenshift,openshift-it $@"


### PR DESCRIPTION
* bump dekorate 2.11.5
* removed Maven Settings from defaulting on the `run_tests_with_dekorate_in_ocp.sh` script

`Automated from ansible update-examples-upstream-versions-playbook`