### PR TITLE
feat: add MAVEN_MIRROR_URL support to s2i scripts

### DIFF
--- a/run_tests_with_s2i.sh
+++ b/run_tests_with_s2i.sh
@@ -3,11 +3,13 @@
 #   . --repository-url
 #   . --branch-to-test
 #   . --maven-settings
+#   . --maven-mirror-url
 #   . --ocp-database-file
 UNMANAGED_PARAMS=""
 SOURCE_REPOSITORY_URL="https://github.com/snowdrop/crud-example"
 SOURCE_REPOSITORY_REF="sb-2.7.x"
 MAVEN_SETTINGS_REF=""
+MAVEN_MIRROR_URL=""
 OCP_DATABASE_FILE=".openshiftio/database.yaml"
 
 while [ $# -gt 0 ]; do
@@ -17,6 +19,7 @@ while [ $# -gt 0 ]; do
       --repository-url) SOURCE_REPOSITORY_URL="$2";;
       --branch-to-test) SOURCE_REPOSITORY_REF="$2";;
       --maven-settings) MAVEN_SETTINGS_REF="-s $2";;
+      --maven-mirror-url) MAVEN_MIRROR_URL="$2";;
       --ocp-database-file) OCP_DATABASE_FILE="$2";;
       *) UNMANAGED_PARAMS="${UNMANAGED_PARAMS} $1 $2";;
     esac;
@@ -39,7 +42,7 @@ fi
 
 # deploy application
 oc create -f .openshiftio/application.yaml
-oc new-app --template=crud -p SOURCE_REPOSITORY_URL=$SOURCE_REPOSITORY_URL -p SOURCE_REPOSITORY_REF=$SOURCE_REPOSITORY_REF
+oc new-app --template=crud -p SOURCE_REPOSITORY_URL=$SOURCE_REPOSITORY_URL -p SOURCE_REPOSITORY_REF=$SOURCE_REPOSITORY_REF -p MAVEN_MIRROR_URL=$MAVEN_MIRROR_URL
 if [[ $(waitFor "crud" "app") -eq 1 ]] ; then
   echo "Application failed to deploy. Aborting"
   exit 1


### PR DESCRIPTION
Add `maven-mirror-url` option to the `run_tests_with_s2i.sh` script